### PR TITLE
score is based on lines passed and not time now

### DIFF
--- a/public/javascripts/app/controllers/gameController.js
+++ b/public/javascripts/app/controllers/gameController.js
@@ -62,6 +62,14 @@
 
 		// Submit your score
 		$scope.submitScore = function() {
+			// recalculate the score to help prevent cheaters from changing their score
+			// there is a leeway of 10 points since it's possible you could have moved backwards
+	    	for (var i = 0; i < obstacles.length; i++) {
+				if (obstacles[i][0].top > player_y && $scope.score - (i + 1) > 10) {
+					$scope.score = i + 1;
+					$scope.$apply();
+				}
+			}
 			var scoreObj = { Username: $rootScope.root.username, Score: $scope.score };
 			var jsonScoreObj = JSON.stringify(scoreObj);
 			var url = 'addscore';


### PR DESCRIPTION
There have been a few related bug reports regarding how the score is kept and how it can be cheated, so I've changed the implementation to keep score based on the number of lines of obstacles you've passed instead of the amount of time you've been playing the game.

This resolves the issue of leaving the tab on your browser (https://github.com/thawkin3/crossyBlock/issues/1) and implements the suggestion for the distance vs. time issue (https://github.com/thawkin3/crossyBlock/issues/5).

I've also re-initialized the variables for score when the game starts, so if you modify the code before you start playing, your changes will be reset. Finally, I've added an extra validation check when the score is submitting to make sure your score adds up correctly in case you modified it with the dev tools during game play. (Helps address https://github.com/thawkin3/crossyBlock/issues/2)